### PR TITLE
ISSUE-#47: refactor/change_arguments_type APIから取得したトレンドデータを扱うモデル名修正

### DIFF
--- a/trend-collector/trendcollector/libs/infrastructures/repositories/trend_repository.py
+++ b/trend-collector/trendcollector/libs/infrastructures/repositories/trend_repository.py
@@ -7,7 +7,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.exc import NoResultFound, OperationalError
 from sqlalchemy.orm import Session, scoped_session, sessionmaker
 
-from ...models import TrendSummary
+from ...models import InputRawTrend, TrendSummary
 from .schemas import TrendTable
 from ...services.accessor import TrendAccessor
 from ...services.custom_exception import NoTrendRecord, DisconnectionDB, SEARCH_ERROR, UPDATE_ERROR, DELETE_ERROR
@@ -63,9 +63,8 @@ class TrendRepository(TrendAccessor):
 
     # Warning: when using `insert on duplicate key update` & `auto_increment` together,
     # ID-like increments will increase rapidly!
-    # https://mariadb.com/kb/en/auto_increment-on-insert-on-duplicate-key-update/
-    def upsert(self, trends: List[WoeidRawTrend]) -> bool:
-        insert_stmt = mysql.insert(TrendTable).values([
+    def insert_trends(self, trends: List[InputRawTrend]) -> bool:
+        insert_stmt = mysql.insert(TrendTable).prefix_with('IGNORE').values([
             dict(
                 name=t.name,
                 query=t.query,

--- a/trend-collector/trendcollector/libs/services/accessor.py
+++ b/trend-collector/trendcollector/libs/services/accessor.py
@@ -1,7 +1,7 @@
 import abc
 from typing import List
 
-from ..models.twitter import TrendSummary, TwitterAccount, WoeidRawTrend
+from ..models.twitter import InputRawTrend, TrendSummary, TwitterAccount
 
 TWITTER_ACCOUNTS = "twitter_accounts"
 FAILED_FETCH_ACCOUNT = "アカウントの取得に失敗"
@@ -29,7 +29,7 @@ class TrendAccessor(metaclass=abc.ABCMeta):
     def list(self, page: int, counts: int) -> List[TrendSummary]: pass
 
     @abc.abstractmethod
-    def upsert(self, trends: List[WoeidRawTrend]) -> bool: pass
+    def insert_trends(self, trends: List[InputRawTrend]) -> bool: pass
 
     @abc.abstractmethod
     def delete(self, _id: int) -> bool: pass

--- a/trend-collector/trendcollector/libs/services/client.py
+++ b/trend-collector/trendcollector/libs/services/client.py
@@ -2,7 +2,7 @@ import abc
 
 from datetime import datetime
 
-from ..models import TwitterAccount, TrendQuery, TrendMetrics
+from ..models import InputRawTrend, TwitterAccount, TrendQuery, TrendMetrics
 
 
 class Twitter(metaclass=abc.ABCMeta):
@@ -13,10 +13,9 @@ class Twitter(metaclass=abc.ABCMeta):
     def get_account(self, _id: int, account_id: int) -> TwitterAccount: pass
 
     @abc.abstractmethod
-    def list_trends(self, woeid: int) -> list[WoeidRawTrend]: pass
+    def list_trends(self, woeid: int) -> [InputRawTrend]: pass
 
     @abc.abstractmethod
     def list_trend_metrics(
             self, query: TrendQuery, start_time: datetime, end_time: datetime, granularity: str
     ) -> TrendMetrics: pass
-


### PR DESCRIPTION
引数の型を修正

トレンドリポジトリのinsert処理の引数名を修正
Twitterクライアントのトレンドリストメソッドの戻り値の型を修正