### PR TITLE
ISSUE-#70: refactor/change_account_router_service Twitterアカウントルータの依存サービスを変更

### DIFF
--- a/trend-collector/trendcollector/libs/infrastructures/api/v1/endpoints/twitter_accounts.py
+++ b/trend-collector/trendcollector/libs/infrastructures/api/v1/endpoints/twitter_accounts.py
@@ -1,34 +1,34 @@
 from fastapi import Path
 
 from ....response import AccountReply, AccountsReply, Account
-from .....services.collector import MediaCollectorSvc
+from .....services.account import TwitterAccountService
 
 
 class TwitterAccountRoutes:
-    def __init__(self, collector: MediaCollectorSvc):
-        self.media_collector = collector
+    def __init__(self, account_svc: TwitterAccountService):
+        self.account_svc = account_svc
 
     async def list_accounts(self):
-        resp = self.media_collector.list_accounts()
-        res = [Account(id=r.id, account_id=r.account_id, name=r.name, display_name=r.display_name) for r in resp]
+        resp = self.account_svc.list()
+        res = [Account(id=r.id, account_id=str(r.account_id), name=r.name, display_name=r.display_name) for r in resp]
         return AccountsReply(result=res)
 
     async def get_my_account(self):
-        resp = self.media_collector.get_me()
+        resp = self.account_svc.get_me()
         return AccountReply(
-            result=Account(id=resp.id, account_id=resp.account_id, name=resp.name, display_name=resp.display_name))
+            result=Account(id=resp.id, account_id=str(resp.account_id), name=resp.name, display_name=resp.display_name))
 
     async def update_my_account(self):
-        resp = self.media_collector.update_me()
+        resp = self.account_svc.update_me()
         return AccountReply(
-            result=Account(id=resp.id, account_id=resp.account_id, name=resp.name, display_name=resp.display_name))
+            result=Account(id=resp.id, account_id=str(resp.account_id), name=resp.name, display_name=resp.display_name))
 
     async def get_account(self, _id: int = Path(gt=0)):
-        resp = self.media_collector.get_account(_id)
+        resp = self.account_svc.get(_id)
         return AccountReply(
-            result=Account(id=resp.id, account_id=resp.account_id, name=resp.name, display_name=resp.display_name))
+            result=Account(id=resp.id, account_id=str(resp.account_id), name=resp.name, display_name=resp.display_name))
 
     async def update_account(self, _id: int = Path(gt=0)):
-        resp = self.media_collector.update_account(_id)
+        resp = self.account_svc.update(_id)
         return AccountReply(
-            result=Account(id=resp.id, account_id=resp.account_id, name=resp.name, display_name=resp.display_name))
+            result=Account(id=resp.id, account_id=str(resp.account_id), name=resp.name, display_name=resp.display_name))

--- a/trend-collector/trendcollector/libs/infrastructures/response.py
+++ b/trend-collector/trendcollector/libs/infrastructures/response.py
@@ -15,7 +15,7 @@ class Token(BaseModel):
 
 class Account(BaseModel):
     id: int = Field(None, example=RECORD_ID)
-    account_id: int = Field(None, example=TWITTER_ACCOUNT_ID)
+    account_id: str = Field(None, example=TWITTER_ACCOUNT_ID)
     name: str = Field(None, example=DISPLAY_NAME)
     display_name: str = Field(None, example=USER_NAME)
 


### PR DESCRIPTION
分離したアカウント処理サービスに変更

サービスインスタンス変数名修正
アカウントレスポンスのアカウントIDを文字列で返すように修正(swaggerで取得値と異なる数値が返って来る)