### PR TITLE
ISSUE-#70: refactor/change_init_twitter_account_routes Twitterルーティングクラス初期化処理の修正

### DIFF
--- a/trend-collector/trendcollector/libs/infrastructures/__init__.py
+++ b/trend-collector/trendcollector/libs/infrastructures/__init__.py
@@ -1,6 +1,7 @@
 from .client import *
 from .conf import *
-from .dependency_injector import (bind_env, create_media_collector, LoggingInjector, TwitterAuthInjector,
+from .dependency_injector import (bind_env, create_twitter_account_binder, create_media_collector,
+                                  LoggingInjector, TwitterAuthInjector, TwitterAccountDependenciesInjector,
                                   MediaCollectorDependenciesInjector, ORMEngineInjector)
 from .logger import *
 from .repositories import *

--- a/trend-collector/trendcollector/libs/infrastructures/conf.py
+++ b/trend-collector/trendcollector/libs/infrastructures/conf.py
@@ -1,7 +1,7 @@
 from pydantic import BaseSettings, validator
 
 RECORD_ID = 1
-TWITTER_ACCOUNT_ID = 1000000000000000
+TWITTER_ACCOUNT_ID = "1000000000000000"
 DISPLAY_NAME = "toyosy012"
 USER_NAME = "toyosy012"
 TREND_NAME = "ばあちゃん卒業"

--- a/trend-collector/trendcollector/libs/infrastructures/dependency_injector.py
+++ b/trend-collector/trendcollector/libs/infrastructures/dependency_injector.py
@@ -43,15 +43,20 @@ def bind_env(binder: Binder):
     )
 
 
-def create_media_collector(
-        trend_accessor: TrendAccessor, twitter_account_accessor: TwitterAccountAccessor, twitter: Twitter
-) -> Callable[[Binder], None]:
+def create_media_collector(repo: TrendAccessor, cli: Twitter) -> Callable[[Binder], None]:
     def _bind_media_collector(binder: Binder) -> None:
-        binder.bind(TrendAccessor, trend_accessor)
-        binder.bind(TwitterAccountAccessor, twitter_account_accessor)
-        binder.bind(Twitter, twitter)
+        binder.bind(TrendAccessor, repo)
+        binder.bind(Twitter, cli)
 
     return _bind_media_collector
+
+
+def create_twitter_account_binder(repo: TwitterAccountAccessor, cli: Twitter) -> Callable[[Binder], None]:
+    def _bind_twitter_account(binder: Binder) -> None:
+        binder.bind(TwitterAccountAccessor, repo)
+        binder.bind(Twitter, cli)
+
+    return _bind_twitter_account
 
 
 class TwitterAuthInjector(Module):
@@ -105,10 +110,12 @@ class LoggingInjector(Module):
 class MediaCollectorDependenciesInjector(Module):
     @singleton
     @provider
-    def provide(
-            self,
-            trend_accessor: TrendAccessor,
-            twitter_account_binder: TwitterAccountAccessor,
-            twitter: Twitter
-    ) -> (TrendAccessor, TwitterAccountAccessor, Twitter):
-        return trend_accessor, twitter_account_binder, twitter
+    def provide(self, trend_accessor: TrendAccessor, twitter: Twitter) -> (TrendAccessor, Twitter):
+        return trend_accessor, twitter
+
+
+class TwitterAccountDependenciesInjector(Module):
+    @singleton
+    @provider
+    def provide(self, repo: TwitterAccountAccessor, cli: Twitter) -> (TwitterAccountAccessor, Twitter):
+        return repo, cli


### PR DESCRIPTION
DIコンテナを分離したTwitterアカウントサービスの初期化するよう修正

注入するTwitterアカウントリポジトリとTwitterクライアントをバインドする関数を定義
TwitterアカウントリポジトリとTwitterクライアントをTwitterアカウントサービスに注入する注入クラスを定義 mainに初期化処理を追加