### PR TITLE
Issue #70 Twitterアカウント処理をコレクトサービスから分離

### DIFF
--- a/trend-collector/trendcollector/libs/infrastructures/__init__.py
+++ b/trend-collector/trendcollector/libs/infrastructures/__init__.py
@@ -1,6 +1,7 @@
 from .client import *
 from .conf import *
-from .dependency_injector import (bind_env, create_media_collector, LoggingInjector, TwitterAuthInjector,
+from .dependency_injector import (bind_env, create_twitter_account_binder, create_media_collector,
+                                  LoggingInjector, TwitterAuthInjector, TwitterAccountDependenciesInjector,
                                   MediaCollectorDependenciesInjector, ORMEngineInjector)
 from .logger import *
 from .repositories import *

--- a/trend-collector/trendcollector/libs/infrastructures/api/v1/endpoints/twitter_accounts.py
+++ b/trend-collector/trendcollector/libs/infrastructures/api/v1/endpoints/twitter_accounts.py
@@ -1,34 +1,34 @@
 from fastapi import Path
 
 from ....response import AccountReply, AccountsReply, Account
-from .....services.collector import MediaCollectorSvc
+from .....services.account import TwitterAccountService
 
 
 class TwitterAccountRoutes:
-    def __init__(self, collector: MediaCollectorSvc):
-        self.media_collector = collector
+    def __init__(self, account_svc: TwitterAccountService):
+        self.account_svc = account_svc
 
     async def list_accounts(self):
-        resp = self.media_collector.list_accounts()
-        res = [Account(id=r.id, account_id=r.account_id, name=r.name, display_name=r.display_name) for r in resp]
+        resp = self.account_svc.list()
+        res = [Account(id=r.id, account_id=str(r.account_id), name=r.name, display_name=r.display_name) for r in resp]
         return AccountsReply(result=res)
 
     async def get_my_account(self):
-        resp = self.media_collector.get_me()
+        resp = self.account_svc.get_me()
         return AccountReply(
-            result=Account(id=resp.id, account_id=resp.account_id, name=resp.name, display_name=resp.display_name))
+            result=Account(id=resp.id, account_id=str(resp.account_id), name=resp.name, display_name=resp.display_name))
 
     async def update_my_account(self):
-        resp = self.media_collector.update_me()
+        resp = self.account_svc.update_me()
         return AccountReply(
-            result=Account(id=resp.id, account_id=resp.account_id, name=resp.name, display_name=resp.display_name))
+            result=Account(id=resp.id, account_id=str(resp.account_id), name=resp.name, display_name=resp.display_name))
 
     async def get_account(self, _id: int = Path(gt=0)):
-        resp = self.media_collector.get_account(_id)
+        resp = self.account_svc.get(_id)
         return AccountReply(
-            result=Account(id=resp.id, account_id=resp.account_id, name=resp.name, display_name=resp.display_name))
+            result=Account(id=resp.id, account_id=str(resp.account_id), name=resp.name, display_name=resp.display_name))
 
     async def update_account(self, _id: int = Path(gt=0)):
-        resp = self.media_collector.update_account(_id)
+        resp = self.account_svc.update(_id)
         return AccountReply(
-            result=Account(id=resp.id, account_id=resp.account_id, name=resp.name, display_name=resp.display_name))
+            result=Account(id=resp.id, account_id=str(resp.account_id), name=resp.name, display_name=resp.display_name))

--- a/trend-collector/trendcollector/libs/infrastructures/client/twitter_v2.py
+++ b/trend-collector/trendcollector/libs/infrastructures/client/twitter_v2.py
@@ -9,11 +9,13 @@ from tweepy.client import Response
 from ..dependency_injector import Authentications
 from ...models import TwitterAccount, InputRawTrend, TrendMetrics, TrendVolume, TrendQuery
 from ...services import client
-from ...services.custom_exception import Timeout, TwitterBadRequest, TwitterUnAuthorized, TwitterForbidden, FETCH_ERROR
+from ...services.custom_exception import (Timeout, TwitterBadRequest, TwitterUnAuthorized,
+                                          TwitterForbidden, TwitterNotFoundAccount, FETCH_ERROR)
 
 FAILED_FETCH_ACCOUNT = "自身のアカウントの取得に失敗"
 FAILED_FETCH_TRENDS = "トレンドリストの取得に失敗"
 FAILED_FETCH_TREND_METRICS = "トレンドメトリクスの取得に失敗"
+NOT_FOUND_ACCOUNT = "Twitterアカウントが存在します"
 
 
 @singleton
@@ -35,8 +37,8 @@ class TwitterV2(client.Twitter):
 
     def get_me(self) -> TwitterAccount:
         try:
-            resp = self.client.get_me()
-            return TwitterAccount(0, resp[0]["id"], resp[0]["name"], resp[0]["username"])
+            resp: Response = self.client.get_me()
+            return TwitterAccount(0, resp.data["id"], resp.data["name"], resp.data["username"])
         except tweepy.Unauthorized as e:
             raise TwitterUnAuthorized(
                 HTTPStatus.INTERNAL_SERVER_ERROR, f"{FETCH_ERROR}: {FAILED_FETCH_ACCOUNT}", e.api_messages)
@@ -50,6 +52,11 @@ class TwitterV2(client.Twitter):
     def get_account(self, _id: int, account_id: int) -> TwitterAccount:
         try:
             resp: Response = self.client.get_user(id=account_id)
+            if resp.data is None:
+                raise TwitterNotFoundAccount(
+                    HTTPStatus.INTERNAL_SERVER_ERROR, f"{FETCH_ERROR}: {FAILED_FETCH_ACCOUNT}",
+                    [f"Not Found twitter account: {account_id}"]
+                )
             return TwitterAccount(_id, resp.data["id"], resp.data["name"], resp.data["username"])
         except tweepy.errors.BadRequest as e:
             raise TwitterBadRequest(

--- a/trend-collector/trendcollector/libs/infrastructures/conf.py
+++ b/trend-collector/trendcollector/libs/infrastructures/conf.py
@@ -1,7 +1,7 @@
 from pydantic import BaseSettings, validator
 
 RECORD_ID = 1
-TWITTER_ACCOUNT_ID = 1000000000000000
+TWITTER_ACCOUNT_ID = "1000000000000000"
 DISPLAY_NAME = "toyosy012"
 USER_NAME = "toyosy012"
 TREND_NAME = "ばあちゃん卒業"

--- a/trend-collector/trendcollector/libs/infrastructures/dependency_injector.py
+++ b/trend-collector/trendcollector/libs/infrastructures/dependency_injector.py
@@ -43,15 +43,20 @@ def bind_env(binder: Binder):
     )
 
 
-def create_media_collector(
-        trend_accessor: TrendAccessor, twitter_account_accessor: TwitterAccountAccessor, twitter: Twitter
-) -> Callable[[Binder], None]:
+def create_media_collector(repo: TrendAccessor, cli: Twitter) -> Callable[[Binder], None]:
     def _bind_media_collector(binder: Binder) -> None:
-        binder.bind(TrendAccessor, trend_accessor)
-        binder.bind(TwitterAccountAccessor, twitter_account_accessor)
-        binder.bind(Twitter, twitter)
+        binder.bind(TrendAccessor, repo)
+        binder.bind(Twitter, cli)
 
     return _bind_media_collector
+
+
+def create_twitter_account_binder(repo: TwitterAccountAccessor, cli: Twitter) -> Callable[[Binder], None]:
+    def _bind_twitter_account(binder: Binder) -> None:
+        binder.bind(TwitterAccountAccessor, repo)
+        binder.bind(Twitter, cli)
+
+    return _bind_twitter_account
 
 
 class TwitterAuthInjector(Module):
@@ -105,10 +110,12 @@ class LoggingInjector(Module):
 class MediaCollectorDependenciesInjector(Module):
     @singleton
     @provider
-    def provide(
-            self,
-            trend_accessor: TrendAccessor,
-            twitter_account_binder: TwitterAccountAccessor,
-            twitter: Twitter
-    ) -> (TrendAccessor, TwitterAccountAccessor, Twitter):
-        return trend_accessor, twitter_account_binder, twitter
+    def provide(self, trend_accessor: TrendAccessor, twitter: Twitter) -> (TrendAccessor, Twitter):
+        return trend_accessor, twitter
+
+
+class TwitterAccountDependenciesInjector(Module):
+    @singleton
+    @provider
+    def provide(self, repo: TwitterAccountAccessor, cli: Twitter) -> (TwitterAccountAccessor, Twitter):
+        return repo, cli

--- a/trend-collector/trendcollector/libs/infrastructures/response.py
+++ b/trend-collector/trendcollector/libs/infrastructures/response.py
@@ -15,7 +15,7 @@ class Token(BaseModel):
 
 class Account(BaseModel):
     id: int = Field(None, example=RECORD_ID)
-    account_id: int = Field(None, example=TWITTER_ACCOUNT_ID)
+    account_id: str = Field(None, example=TWITTER_ACCOUNT_ID)
     name: str = Field(None, example=DISPLAY_NAME)
     display_name: str = Field(None, example=USER_NAME)
 

--- a/trend-collector/trendcollector/libs/services/__init__.py
+++ b/trend-collector/trendcollector/libs/services/__init__.py
@@ -1,4 +1,5 @@
 from .accessor import *
+from .account import TwitterAccountService
 from .client import Twitter
 from .collector import TwitterCollector, MediaCollectorSvc
 from .custom_exception import CustomException, APIErrorResponse

--- a/trend-collector/trendcollector/libs/services/account.py
+++ b/trend-collector/trendcollector/libs/services/account.py
@@ -1,0 +1,30 @@
+from injector import inject, singleton
+
+from ..services.accessor import TwitterAccount, TwitterAccountAccessor
+from ..services.client import Twitter
+
+
+@singleton
+class TwitterAccountService:
+    @inject
+    def __init__(self, repo: TwitterAccountAccessor, cli: Twitter):
+        self.account_repo = repo
+        self.cli = cli
+
+    def get_me(self) -> TwitterAccount:
+        return self.cli.get_me()
+
+    def update_me(self) -> TwitterAccount:
+        my_account = self.get_me()
+        return self.account_repo.update_account(my_account)
+
+    def get(self, _id: int) -> TwitterAccount:
+        return self.account_repo.get_account(_id)
+
+    def list(self) -> list[TwitterAccount]:
+        return self.account_repo.list_accounts()
+
+    def update(self, _id: int) -> TwitterAccount:
+        old = self.account_repo.get_account(_id)
+        account = self.cli.get_account(_id, old.account_id)
+        return self.account_repo.update_account(account)

--- a/trend-collector/trendcollector/libs/services/collector.py
+++ b/trend-collector/trendcollector/libs/services/collector.py
@@ -4,27 +4,12 @@ from datetime import datetime
 from injector import inject, singleton
 from typing import Union
 
-from ..models import TrendMetrics, TrendSummary, TwitterAccount, TrendQuery, InputRawTrend
+from ..models import TrendMetrics, TrendSummary, TrendQuery, InputRawTrend
 from ..services.client import Twitter
-from .accessor import TrendAccessor, TwitterAccountAccessor
+from .accessor import TrendAccessor
 
 
 class MediaCollectorSvc(metaclass=abc.ABCMeta):
-    @abc.abstractmethod
-    def get_me(self) -> TwitterAccount: pass
-
-    @abc.abstractmethod
-    def update_me(self) -> TwitterAccount: pass
-
-    @abc.abstractmethod
-    def list_accounts(self) -> list[TwitterAccount]: pass
-
-    @abc.abstractmethod
-    def get_account(self, account_id: int) -> TwitterAccount: pass
-
-    @abc.abstractmethod
-    def update_account(self, account_id: int) -> TwitterAccount: pass
-
     @abc.abstractmethod
     def get_trend(self, _id: int) -> TrendSummary: pass
 
@@ -47,28 +32,9 @@ class MediaCollectorSvc(metaclass=abc.ABCMeta):
 class TwitterCollector(MediaCollectorSvc):
 
     @inject
-    def __init__(self, trend_repo: TrendAccessor, twitter_accessor_repo: TwitterAccountAccessor, twitter_cli: Twitter):
+    def __init__(self, trend_repo: TrendAccessor, twitter_cli: Twitter):
         self.trend_repo = trend_repo
-        self.twitter_account_repo = twitter_accessor_repo
         self.twitter_cli = twitter_cli
-
-    def get_me(self) -> TwitterAccount:
-        return self.twitter_cli.get_me()
-
-    def update_me(self) -> TwitterAccount:
-        my_account = self.get_me()
-        return self.twitter_account_repo.update_account(my_account)
-
-    def list_accounts(self) -> list[TwitterAccount]:
-        return self.twitter_account_repo.list_accounts()
-
-    def get_account(self, _id: int) -> TwitterAccount:
-        return self.twitter_account_repo.get_account(_id)
-
-    def update_account(self, _id: int) -> TwitterAccount:
-        old = self.twitter_account_repo.get_account(_id)
-        account = self.twitter_cli.get_account(_id, old.account_id)
-        return self.twitter_account_repo.update_account(account)
 
     def get_trend(self, _id: int) -> TrendSummary:
         return self.trend_repo.get(_id)

--- a/trend-collector/trendcollector/libs/services/custom_exception.py
+++ b/trend-collector/trendcollector/libs/services/custom_exception.py
@@ -16,6 +16,11 @@ class TwitterException(CustomException):
         super().__init__(code, message, details)
 
 
+class TwitterNotFoundAccount(TwitterException):
+    def __init__(self, code: int, message: str, details: list[str]):
+        super().__init__(code, message, details)
+
+
 class TwitterBadRequest(TwitterException):
     def __init__(self, code: int, message: str, details: list[str]):
         super().__init__(code, message, details)


### PR DESCRIPTION
Twitterアカウント処理を定義するサービスクラスを定義
サービスクラスの初期化をDIコンテナを使用して実装
Twitterアカウント処理のハンドラクラスに新しく定義したサービスクラスを与えるように修正