### PR TITLE
#90: costome_exceptionモジュールのuseless-parent-delegationの解決

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -21,6 +21,7 @@ jobs:
         with:
           python-version: 'pypy3.9'
       - run: pip install -r dev-requirements.txt
+        id: dependencies
       - uses: ricardochaves/python-lint@v1.4.0
         with:
           python-root-list: "trendcollector"

--- a/trend-collector/trendcollector/libs/services/custom_exception.py
+++ b/trend-collector/trendcollector/libs/services/custom_exception.py
@@ -12,48 +12,39 @@ class CustomException(Exception):
 
 
 class TwitterException(CustomException):
-    def __init__(self, code: int, message: str, details: list[str]):
-        super().__init__(code, message, details)
+    """There is no need to override '__init__'."""
 
 
 class TwitterNotFoundAccount(TwitterException):
-    def __init__(self, code: int, message: str, details: list[str]):
-        super().__init__(code, message, details)
+    """There is no need to override '__init__'."""
 
 
 class TwitterBadRequest(TwitterException):
-    def __init__(self, code: int, message: str, details: list[str]):
-        super().__init__(code, message, details)
+    """There is no need to override '__init__'."""
 
 
 class TwitterUnAuthorized(CustomException):
-    def __init__(self, code: int, message: str, details: list[str]):
-        super().__init__(code, message, details)
+    """There is no need to override '__init__'."""
 
 
 class TwitterForbidden(TwitterException):
-    def __init__(self, code: int, message: str, details: list[str]):
-        super().__init__(code, message, details)
+    """There is no need to override '__init__'."""
 
 
 class IntervalServerException(CustomException):
-    def __init__(self, code: int, message: str, details: list[str]):
-        super().__init__(code, message, details)
+    """There is no need to override '__init__'."""
 
 
 class Timeout(IntervalServerException):
-    def __init__(self, code: int, message: str, details: list[str]):
-        super().__init__(code, message, details)
+    """There is no need to override '__init__'."""
 
 
 class DataBaseException(CustomException):
-    def __init__(self, code: int, message: str, details: list[str]):
-        super().__init__(code, message, details)
+    """There is no need to override '__init__'."""
 
 
 class DisconnectionDB(DataBaseException):
-    def __init__(self, code: int, message: str, details: list[str]):
-        super().__init__(code, message, details)
+    """There is no need to override '__init__'."""
 
 
 class NoTrendRecord(DataBaseException):


### PR DESCRIPTION
Useless parent or super() delegation in method '__init__'解決のためコメントに置き換え