### PR TITLE
ISSUE-#97: refactor/change_linter_max_line_len ツイッタークライアント実装修正

### DIFF
--- a/trend-collector/pylintrc
+++ b/trend-collector/pylintrc
@@ -332,7 +332,7 @@ indent-after-paren=4
 indent-string='    '
 
 # Maximum number of characters on a single line.
-max-line-length=100
+max-line-length=120
 
 # Maximum number of lines in a module.
 max-module-lines=1000


### PR DESCRIPTION
linterエラー修正

1行毎の最大長を120文字に修正