### PR TITLE
ISSUE-#97: refactor/change_twitter_accounts_repo ツイッターアカウントリポジトリ修正

### DIFF
--- a/trend-collector/trendcollector/libs/infrastructures/repositories/twitter_account.py
+++ b/trend-collector/trendcollector/libs/infrastructures/repositories/twitter_account.py
@@ -36,7 +36,7 @@ class TwitterAccountRepository(TwitterAccountAccessor):
             raise DisconnectionDB(
                 HTTPStatus.INTERNAL_SERVER_ERROR,
                 f"{SEARCH_ERROR}: {FAILED_FETCH_ACCOUNTS}", list(e.args)
-            )
+            ) from e
         finally:
             session.close()
         return [
@@ -58,12 +58,12 @@ class TwitterAccountRepository(TwitterAccountAccessor):
         except NoResultFound as e:
             raise NoTwitterAccountRecord(
                 HTTPStatus.BAD_REQUEST, UPDATE_ERROR, list(e.args)
-            )
+            ) from e
         except OperationalError as e:
             raise DisconnectionDB(
                 HTTPStatus.INTERNAL_SERVER_ERROR,
                 f"{UPDATE_ERROR}: {FAILED_UPDATE_ACCOUNT}", list(e.args)
-            )
+            ) from e
         finally:
             session.close()
         return TwitterAccount(n.id, n.account_id, n.name, n.display_name)
@@ -76,10 +76,10 @@ class TwitterAccountRepository(TwitterAccountAccessor):
         except NoResultFound as e:
             raise NoTwitterAccountRecord(
                 HTTPStatus.BAD_REQUEST, SEARCH_ERROR, list(e.args)
-            )
+            ) from e
         except OperationalError as e:
             raise DisconnectionDB(
                 HTTPStatus.INTERNAL_SERVER_ERROR, f"{SEARCH_ERROR}: {FAILED_FETCH_ACCOUNT}", list(e.args)
-            )
+            ) from e
         finally:
             session.close()

--- a/trend-collector/trendcollector/libs/services/accessor.py
+++ b/trend-collector/trendcollector/libs/services/accessor.py
@@ -16,7 +16,7 @@ class TwitterAccountAccessor(metaclass=abc.ABCMeta):
         pass
 
     @abc.abstractmethod
-    def update_account(self, account: TwitterAccount) -> TwitterAccount:
+    def update_account(self, new: TwitterAccount) -> TwitterAccount:
         pass
 
     @abc.abstractmethod


### PR DESCRIPTION
lintエラー修正

例外チェインに処理で発生した例外を包含するように修正
アカウントアップデートメソッドのインターフェースの引数名を修正